### PR TITLE
Updates to matrix tool and main README file

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,7 +33,9 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # some complex nesting. This is not universally good software engineering pratice,
 # but this makes some of the code (such as loops handling multi-dimensional matrix
 # unrolling) more natural.
-disable=too-many-arguments,
+disable=unknown-option-value,
+        too-many-arguments,
+        too-many-positional-arguments,
         too-many-branches,
         too-many-locals,
         too-many-lines,

--- a/.pylintrc
+++ b/.pylintrc
@@ -72,3 +72,4 @@ ignore-comments=yes
 ignore-docstrings=yes
 ignore-imports=no
 defining-attr-methods=__init__
+load-plugins=pylint.extensions.no_self_use

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 AMD Matrix Instruction Calculator
-=====================================================================================
+=======================================================================================================
 
 This repository contains a tool for generating information about the matrix multiplication instructions in AMD Radeon&trade; and AMD Instinct&trade; accelerators.
 This tool allows users to generate instruction-level information such as computational throughput and register usage.
@@ -23,7 +23,7 @@ Some matrix multiplication instructions may be modified by fields in the instruc
 This tool allows setting these fields, which may modify the output of the other queries.
 
 Table of Contents
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 
 * [AMD Matrix Instruction Calculator](#amd-matrix-instruction-calculator)
     * [Prerequisites](#prerequisites)
@@ -31,6 +31,7 @@ Table of Contents
         * [General-purpose Configuration Parameters](#general-purpose-configuration-parameters)
         * [Querying Matrix Multiplication Instruction Information](#querying-matrix-multiplication-instruction-information)
         * [Choosing the Matrix to Query](#choosing-the-matrix-to-query)
+        * [Modifying the Queried Matrix](#modifying-the-queried-matrix)
         * [Querying Register and Lane Information for a Single Matrix Element](#querying-register-and-lane-information-for-a-single-matrix-element)
         * [Querying the Matrix Element Coordinates for a Register and Lane Combination](#querying-the-matrix-element-coordinates-for-a-register-and-lane-combination)
         * [Printing the Register and Lane Layout for an Entire Matrix](#printing-the-register-and-lane-layout-for-an-entire-matrix)
@@ -43,22 +44,22 @@ Table of Contents
         * [Example of Querying the Source Matrix Entries for D Matrix Outputs](#example-of-querying-the-source-matrix-entries-for-d-matrix-outputs)
     * [Example of Printing the Registers and Lanes for an Entire Matrix](#example-of-printing-the-registers-and-lanes-for-an-entire-matrix)
     * [Example of Printing the Matrix Elements for all Registers and Lanes](#example-of-printing-the-matrix-elements-for-all-registers-and-lanes)
-     * [Examples of Setting Modifiers on AMD CDNA™ Architectures](#examples-of-setting-modifiers-on-amd-cdna-architectures)
+     * [Examples of Setting Modifiers in AMD CDNA™ Architectures](#examples-of-setting-modifiers-in-amd-cdna-architectures)
         * [Example of Using the CBSZ and ABID Modifiers to Change the A Matrix Layout](#example-of-using-the-cbsz-and-abid-modifiers-to-change-the-a-matrix-layout)
         * [Example of Using the BLGP Modifier to Change the B Matrix Layout](#example-of-using-the-blgp-modifier-to-change-the-b-matrix-layout)
-            * [Example of Using the BLGP Modifier to Negate Input Matrices on CDNA™ 3 Architectures](#example-of-using-the-blgp-modifier-to-negate-input-matrices-on-cdna-3-architectures)
+            * [Example of Using the BLGP Modifier to Negate FP64 Input Matrices in the CDNA™ 3 Architecture](#example-of-using-the-blgp-modifier-to-negate-fp64-input-matrices-in-the-cdna-3-architecture)
         * [Example of Printing Compression Index Information for a Sparse Matrix Instruction](#example-of-printing-compression-index-information-for-a-sparse-matrix-instruction)
-    * [Examples of Setting Modifiers on AMD RDNA™ Architectures](#examples-of-setting-modifiers-on-amd-rdna-architectures)
-        * [Example of Using the OPSEL Modifier to Change the C and D Matrix Storage](#example-of-using-the-opsel-modifier-to-change-the-c-and-d-matrix-storage)
+    * [Examples of Setting Modifiers in the AMD RDNA™ 3 Architecture](#examples-of-setting-modifiers-in-the-amd-rdna-3-architecture)
+        * [Example of Using the OPSEL Modifier to Change the C and D Matrix Storage in the AMD RDNA™ 3 Architecture](#example-of-using-the-opsel-modifier-to-change-the-c-and-d-matrix-storage-in-the-amd-rdna-3-architecture)
         * [Example of Using the NEG Modifier to Negate Input Matrices](#example-of-using-the-neg-modifier-to-negate-input-matrices)
     * [Details of AMD Matrix Multiplication Instruction Encodings](#details-of-amd-matrix-multiplication-instruction-encodings)
-        * [Details of the VOP3P-MAI Matrix Multiplication Instruction Encoding for AMD CDNA™ 1 - CDNA 3 Architectures](#details-of-the-vop3p-mai-matrix-multiplication-instruction-encoding-for-amd-cdna-1-cdna-3-architectures)
-        * [Details of the VOP3P Matrix Multiplication Instruction Encoding for AMD RDNA™ 3 Architectures](#details-of-the-vop3p-matrix-multiplication-instruction-encoding-for-amd-rdna-3-architectures)
+        * [Details of the VOP3P-MAI Matrix Multiplication Instruction Encoding in the AMD CDNA™ 1 - CDNA 3 Architectures](#details-of-the-vop3p-mai-matrix-multiplication-instruction-encoding-in-the-amd-cdna-1---cdna-3-architectures)
+        * [Details of the VOP3P Matrix Multiplication Instruction Encoding in the AMD RDNA™ 3 Architecture](#details-of-the-vop3p-matrix-multiplication-instruction-encoding-in-the-amd-rdna-3-architecture)
     * [Further Materials](#further-materials)
     * [Trademark Attribution](#trademark-attribution)
 
 Prerequisites
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 This tool requires the following:
 * Python3
 * The Python package `tabulate`:
@@ -71,7 +72,7 @@ This tool requires the following:
 * Now users can use `pip install -r requirements.txt` to install dependent packages
 
 Calculator Usage
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 This tool offers many command line parameters to configure the desired information to print.
 This section details what these parameters do and how users should configure them to achieve desired results.
 
@@ -112,14 +113,14 @@ This tool allows setting these modifiers on instructions that support them.
 The modifiers will change the output of register and matrix element queries to match what the instruction would do with the modifier fields set.
 
 * `--cbsz {#}`: Change the Control Broadcast Size field on instructions that support it. This causes some blocks of the A matrix to be broadcast to the Matrix Core in place of other blocks. This modifier configures how many blocks will receive that broadcast, the ABID modifier chooses which block to broadcast. This is only supported by some instructions and is only useful for queries of the A and K matrices. The legal values are between 0 and $`log_2(blocks)`$, inclusive.
-* `--abid {#}`: Change the A-matrix Broadcast Identifier field on instructions that support it. This chooses the block of the A matrix to broadcast to the Matrix Core, in conjunction with the CBSZ modifier. This is only supported by some instructions and is only useful for queries of the A and K matrices. The legal values are between 0 and $`2^{CBSZ}-1`$, inclusive.
+* `--abid {#}`: Change the A-matrix Broadcast Identifier field on instructions that support it. In some architectures, this chooses the block of the dense A matrix to broadcast to the Matrix Core, in conjunction with the CBSZ modifier. This is only supported by some instructions and is only useful for queries of the A and K matrices. For these instructions, the legal values are between 0 and $`2^{CBSZ}-1`$, inclusive. In other architectures, this is used to pick between compression index sets.
 * `--blgp {#}`: Change the B-matrix Lane Group Pattern field on instructions that support it. This causes some input lanes of the B matrix to be rotated or broadcast to replace the matrix multiplication inputs that would have originally come from a different lane. This is only supported by some instructions. For instructions where it is supported, valid values are between 0-7, inclusive.
-* `--opsel {#}`: Change the Operand Select field on instructions that support it. This causes some 16-bit inputs and outputs to be stored in either the top or bottom half of the 32-bit registers, rather than packing two values into the register. For those instructions, this field chooses whether to read and write from the top of bottom half of those registers.
+* `--opsel {#}`: Change the Operand Select field on instructions that support it. In some architectures, this causes some 16-bit inputs and outputs to be stored in either the top or bottom half of the 32-bit registers, rather than packing two values into the register. For those instructions, this field chooses whether to read and write from the top of bottom half of those registers. In other architectures, this is used to pick between compression index sets.
 * `--neg {#}`: Change the NEG (Negate) field on instructions that support it. The bits in this 3-bit field indicate whether to negate the values read from the A\[\], B\[\], or C\[\] matrices, respectively. For instructions where it is supported, valid values are between 0-7, inclusive.
-* `--neg_hi {#}`: Change the NEG\_HI (Negate Hi Bits) field on instructions that support it. The bits in this 3-bit field indicate whether to negate the values read from the A\[\], B\[\], or C\[\] matrices, respectively. For instructions where it is supported, valid values are between 0-7, inclusive.
+* `--neg_hi {#}`: Change the NEG\_HI (Negate Hi Bits) field on instructions that support it. The bits in this 3-bit field indicate whether to negate the values read from the A\[\] or B\[\] matrices, or to take the absolute value from C\[\] matrices. For instructions where it is supported, valid values are between 0-7, inclusive.
 
 ### Querying Register and Lane Information for a Single Matrix Element
-The `--get-register` parameter will cause the tool to print the vector register number and the lane within that vector register that holds the matrix element at a single coordinate within the desired matrix.
+The `--get-register` parameter will cause the tool to print the vector register number, the lane within that vector register, and the bits within each vector register lane that holds the matrix element at a single coordinate within the desired matrix.
 
 * `--get-register` (or `-g`): This parameter can be further configured using some of the following options. The options used depend on both the instruction and matrix being queried.
     * `--I-coordinate {#}` (or `-I {#}`): Chooses the i coordinate, the row for A, C, D, or K matrices. Ignored for B matrix. Default value when this option is not used is 0.
@@ -133,13 +134,13 @@ The `--matrix-entry` parameter will cause the tool to print the row, column, and
 
 * `--matrix-entry` (or `-m`): This parameter can be further configured using the following options.
     * `--register {#}` (or `-r {#}`): Chooses the register number to query. The number must be a whole number (&ge; 0). The maximum register value depends on the chosen instruction. Default value when this option is not used is 0.
-    * `--lane {#}` (or `-l {#}`): Chooses the vector lane within the register to query. This number must be between 0 and 63, inclusive. Default value when this option is not used is 0.
+    * `--lane {#}` (or `-l {#}`): Chooses the vector lane within the register to query. This number must be between 0 and the size of the wave minus 1, inclusive. Default value when this option is not used is 0.
     * `--output-calculation` (or `-o`): This option is only valid with the `--D-matrix` parameter. With this option set, the tool will print the row, column, and block information for both the D output matrix and all of the A, B, and C matrix entries that went into calculating it.
 
 ### Printing the Register and Lane Layout for an Entire Matrix
 The `--register-layout` parameter will print a tabular layout of the chosen matrix.
 For each element in the matrix, print out the vector register number that will be used and the lane within that register.
-If a single 32b register holds multiple matrix elements, it will differentiate the lo/hi nibble, or the bits within the register that holds the element.
+If a single 32b register holds multiple matrix elements, it will differentiate the bits within the register that holds the element.
 
 * `--register-layout` (or `-R`): Print the registers and lanes for each element of the chosen matrix. This will print in an ASCII tabular format by default.
     * `--csv` (or `-c`): If this option is also passed, the tool will print the same information, but in a CSV (comma-separated value) format instead of an ASCII table.
@@ -150,7 +151,7 @@ If a single 32b register holds multiple matrix elements, it will differentiate t
 ### Printing the Matrix Element Layout for all Registers and Lanes
 The `--matrix-layout` parameter will print a tabular layout of the chosen matrix.
 For each register used by the matrix, and the lanes within those registers, print out the matrix element or elements that are stored in that register + lane combination.
-If a single 32b register holds multiple matrix elements, the tool will print out the table split into nibbles, bytes, or bits (whatever holds a single element).
+If a single 32b register holds multiple matrix elements, the tool will print out the table split into bit ranges.
 
 * `--matrix-layout` (or `-M`): Print the matrix elements for each register/lane combination. This will print in an ASCII tabular format by default.
     * `--csv` (or `-c`): If this option is also passed, the tool will print the same information, but in a CSV (comma-separated value) format instead of an ASCII table.
@@ -159,8 +160,8 @@ If a single 32b register holds multiple matrix elements, the tool will print out
     * `--transpose`: If this option is also passed, the tool will print the register layout in a transposed format, swapping rows and columns.
 
 Example of Querying the List of Instructions in a Chip
--------------------------------------------------------------------------------------
-The `--list-instructions` flag allows users to query which matrix multiplication instructions are available on a chosen architecture.
+-------------------------------------------------------------------------------------------------------
+The `--list-instructions` flag allows users to query which matrix multiplication instructions are available in a chosen architecture.
 These are the instructions that are supported by the `--instruction` flag.
 
 The following is an example usage, where we query the list of instructions in the CDNA&trade; 2 architecture:
@@ -197,8 +198,8 @@ Available instructions in the CDNA2 architecture:
 ```
 
 Example of Querying Instruction Information
--------------------------------------------------------------------------------------
-The `--detail-instruction` flag allows users to query information about the desired matrix multiplication instruction on a chosen architecture.
+-------------------------------------------------------------------------------------------------------
+The `--detail-instruction` flag allows users to query information about the desired matrix multiplication instruction in a chosen architecture.
 This information includes:
 * The instruction encoding class and opcode
 * The matrix dimensions and number of blocks used by the instruction
@@ -211,7 +212,7 @@ This information includes:
 
 This flag requires the `--architecture` and `--instruction` flags to be set to pick the chip and instruction to detail.
 
-The following is an example usage, where we are querying information about the V\_MFMA\_F32\_4X4X1F32 instruction on the CDNA&trade; 2 architecture:
+The following is an example usage, where we are querying information about the V\_MFMA\_F32\_4X4X1F32 instruction in the CDNA&trade; 2 architecture:
 ```
 $ ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f32_4x4x1f32 --detail-instruction
 Architecture: CDNA2
@@ -277,7 +278,7 @@ Instruction: V_MFMA_F32_4X4X1F32
 ```
 
 Example of Querying Register and Lane for a Single Matrix Element
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 The `--get-register` flag allows users to query an element within a matrix for a desired instruction.
 The tool will then translate this matrix entry into the vector register and lane number within that register that contain the value.
 
@@ -293,7 +294,7 @@ Any parameter that is not explicitly set will default to 0.
 The output format is printed in the form: `Vx{y}.z`, where:
 * `x` is the vector register offset from the value put into the matrix multiplication instruction's register field.
 Registers holding 64-bit values are printed as a register pair, `[x+1:x]`.
-* `y` is the lane within the 64-wide vector register
+* `y` is the lane within the vector register
 * `.z` is an optional identifier for sub-register if the matrix value is less than 32 bits
     * `.[15:0]` is the least significant 16b of a 32b register
     * `.[31:16]` is the most significant 16b of a 32b register
@@ -303,7 +304,7 @@ Registers holding 64-bit values are printed as a register pair, `[x+1:x]`.
     * `.[31:24]` is the most significant 8b of a 32b register
     * `.[hi_bit:lo_bit]` is also used to show the bit-range for values smaller than 8b
 
-The following is an example that requests the register which holds the 16-bit value in the 4th block of matrix A at coordinate `A[1][2]` of the V\_MFMA\_F32\_4X4X4F16 on the CDNA&trade; 2 architecture:
+The following is an example that requests the register which holds the 16-bit value in the 4th block of matrix A at coordinate `A[1][2]` of the V\_MFMA\_F32\_4X4X4F16 in the CDNA&trade; 2 architecture:
 ```
 $ ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f32_4x4x4f16 --get-register --I-coordinate 1 --K-coordinate 2 --block 4 --A-matrix
 Architecture: CDNA2
@@ -326,7 +327,7 @@ The register name to matrix mapping can be found by querying the instruction usi
 
 This option is only valid when the `--D-matrix` parameter is used.
 
-The following is an example that requests the output register and input registers used to calculate the value at coordinate `D[3][2]` of the 1st block for the instruction V\_MFMA\_F32\_4X4X4F16 on the CDNA&trade; 2 architecture:
+The following is an example that requests the output register and input registers used to calculate the value at coordinate `D[3][2]` of the 1st block for the instruction V\_MFMA\_F32\_4X4X4F16 in the CDNA&trade; 2 architecture:
 ```
 $ ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f32_4x4x4f16 --get-register --I-coordinate 3 --J-coordinate 2 --block 1 --D-matrix --output-calculation
 Architecture: CDNA2
@@ -337,7 +338,7 @@ D[3][2].B1 = Vdst_v3{6} = Src0_v0{7}.[15:0]*Src1_v0{6}.[15:0] + Src0_v0{7}.[31:1
 This output shows the four multiplications and five additions that are used to calculate this output matrix entry, as well as which registers are used as input to these calculations.
 
 Example of Querying Matrix Element Information for a Register and Lane
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 The `--matrix-entry` flag allows users to query a register and lane combination for a desired instruction.
 The tool will then translate this vector-lane pair into the matrix entry (or entries) that it holds.
 
@@ -353,7 +354,7 @@ The output format is printed in the form: `Matrix[row][col].block`, where:
 * `col` is the column of the matrix, such as the `k` input to the A matrix or the `j` input to the B matrix
 * `.block` is the block within the matrix, since some matrix multiplication instructions work on multiple separate blocks of $`NxMxK`$ matrix multiplications
 
-The following is an example that requests the matrix entries which are contained in the 17th lane of register 1 of matrix A for the instruction V\_MFMA\_F32\_4X4X4F16 on the CDNA&trade; 2 architecture:
+The following is an example that requests the matrix entries which are contained in the 17th lane of register 1 of matrix A for the instruction V\_MFMA\_F32\_4X4X4F16 in the CDNA&trade; 2 architecture:
 ```
 $ ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f32_4x4x4f16 --matrix-entry --register 1 --lane 17 --A-matrix
 Architecture: CDNA2
@@ -375,7 +376,7 @@ This can be useful when debugging incorrect answers because it allows developers
 
 This option is only valid when the `--D-matrix` parameter is used.
 
-The following is an example that requests the output matrix entry and input matrix entries used to calculate the value at coordinate the 33rd lane of register 2 for matrix D for the instruction V\_MFMA\_F32\_4X4X4F16 on the CDNA&trade; 2 architecture:
+The following is an example that requests the output matrix entry and input matrix entries used to calculate the value at coordinate the 33rd lane of register 2 for matrix D for the instruction V\_MFMA\_F32\_4X4X4F16 in the CDNA&trade; 2 architecture:
 ```
 $ ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f32_4x4x4f16 --matrix-entry --register 2 --lane 33 --D-matrix --output-calculation
 Architecture: CDNA2
@@ -386,7 +387,7 @@ v2{33} = D[2][1].B8 = A[2][0].B8*B[0][1].B8 + A[2][1].B8*B[1][1].B8 + A[2][2].B8
 This output shows the four multiplications and five additions that are used to calculate this output matrix entry, including what their `i`, `j`, and `k` coordinates are, as well as their block number.
 
 Example of Printing the Registers and Lanes for an Entire Matrix
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 The `--register-layout` flag allows users to query the register and lane locations for all entries in a target matrix.
 The tool will translate each matrix coordinate into a register description, format the matrix as a table, and print it to the screen.
 
@@ -402,7 +403,7 @@ In all cases, users may want to pipe the output into another tool such as `less 
 Finally, the optional `--transpose` parameter will swap output table's rows and column.
 This will not cause any change to the matrix itself or the registers that hold the matrix entries; the `--transpose` parameter only changes the layout of the data output by this tool.
 
-The following is an example that requests the layout of the matrix D for the V\_MFMA\_F64\_4X4X4F64 instruction on CDNA&trade; 2 architecture.
+The following is an example that requests the layout of the matrix D for the V\_MFMA\_F64\_4X4X4F64 instruction in CDNA&trade; 2 architecture.
 ```
 $ ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f64_4x4x4f64 --register-layout --D-matrix
 Architecture: CDNA2
@@ -460,7 +461,7 @@ This instruction has four output blocks, and they are printed one after another.
 Each block is a 4x4 matrix; each entry is printed in the same `Vx{y}.z` format described in [the previous section](#example-of-querying-register-and-lane-for-a-single-matrix-element).
 
 Example of Printing the Matrix Elements for all Registers and Lanes
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 The `--matrix-layout` flag allows users to query the matrix entry locations for all the registers used by a matrix multiplication instruction for one of its input matrices.
 The tool will translate the lanes in each matrix into the matrix entry at that coordinate, format this output as a table, and print it to the screen.
 
@@ -476,7 +477,7 @@ In all cases, users may want to pipe the output into another tool such as `less 
 Finally, the optional `--transpose` parameter will swap output table's rows and column.
 This will not cause any change to the matrix itself or the registers that hold the matrix entries; the `--transpose` parameter only changes the layout of the data output by this tool.
 
-The following is an example that requests entries for all registers used by the V\_MFMA\_F64\_4X4X4F64 instruction on the CDNA&trade; 2 architecture.
+The following is an example that requests entries for all registers used by the V\_MFMA\_F64\_4X4X4F64 instruction in the CDNA&trade; 2 architecture.
 ```
 ./matrix_calculator.py --architecture cdna2 --instruction v_mfma_f64_4x4x4f64 --matrix-layout --D-matrix
 Architecture: CDNA2
@@ -617,8 +618,8 @@ Instruction: V_MFMA_F64_4X4X4F64
 This instruction only requires a single vector register-pair (because it has a 64b output), so it only has one column of 64 entries: one entry per lane.
 Each entry is printed in the same `Matrix[row][col].block` format described in [the previous section](#example-of-querying-matrix-element-information-for-a-register-and-lane).
 
-Examples of Setting Modifiers on AMD CDNA&trade; Architectures
--------------------------------------------------------------------------------------
+Examples of Setting Modifiers in AMD CDNA&trade; Architectures
+-------------------------------------------------------------------------------------------------------
 AMD Instinct&trade; accelerators that use CDNA architectures allow setting modifier fields that change how the matrix multiplication instructions access data out of registers.
 Examples of using these fields, `CBSZ`, `ABID`, and `BLGP`, are shown below.
 The CDNA 3 architecture also allows sparse matrix multiplication, which has a separate compression index matrix.
@@ -961,20 +962,20 @@ Block 3
 +-----------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+----------------+
 ```
 
-#### Example of Using the BLGP Modifier to Negate Input Matrices on CDNA&trade; 3 Architectures
--------------------------------------------------------------------------------------
+#### Example of Using the BLGP Modifier to Negate FP64 Input Matrices in the CDNA&trade; 3 Architecture
+-------------------------------------------------------------------------------------------------------
 The CDNA&trade; 2 architecture added support for matrix multiplication instructions that use double-precision floating point (FP64) numbers.
 In the accelerators using the CDNA 2 architecture, the BLGP field is disallowed.
 The AMD Instinct&trade; MI300 accelerators use the CDNA 3 architecture and enhance the 64-bit floating point matrix multiplication instructions to use the BLGP fields.
-However, the BLGP modifier field does not affect these FP64 MFMA instructions [as described above](#example-of-using-the-blgp-modifier-to-change-the-b-matrix-layout).
+However, the BLGP modifier field does not affect these FP64 MFMA instructions [in the manner described above](#example-of-using-the-blgp-modifier-to-change-the-b-matrix-layout).
 
-Instead, on CDNA 3 accelerators, the three bits of the BLGP modifier are used to indicate if the three input matrices (A, B, and/or C) should have their values negated before being sent to the Matrix Core.
+Instead, in CDNA 3 accelerators, the three bits of the BLGP modifier are used to indicate if the three input matrices (A, B, and/or C) should have their values negated before being sent to the Matrix Core.
 Setting the lowest-order bit of BLGP will negate Src0, the values of the A matrix.
 Setting the middle bit of BLGP will negate Src1, the values of the B matrix.
 Setting the highest-order bit of BLGP will negate Src3, the values of the C matrix.
 Any of the bits may be set at the same time.
 
-The following is an example that requests the matrix layout of the matrix B for the V\_MFMA\_F64\_16X16X4_F64 instruction on CDNA 3 architecture, with the BLGP value of 6.
+The following is an example that requests the matrix layout of the matrix B for the V\_MFMA\_F64\_16X16X4\_F64 instruction in the CDNA 3 architecture, with the BLGP value of 6.
 Because the value 6 has the middle bit set, the values of the B\[\] matrix are returned with a negative sign to indicate that their values will be negated by the instruction.
 ```
 ./matrix_calculator.py --architecture cdna3 --instruction v_mfma_f64_16x16x4_f64 --matrix-layout --B-matrix --blgp 6
@@ -1142,15 +1143,15 @@ This indicates that the compression bits for this entry, if it exists in the mat
 Or they should be placed into the 6th and 7th bits, if this is the second value contained in the post-compression block.
 
 The `--cbsz` and `--abid` modifiers can also affect the output of the compression index.
-Because the VGPR that holds the compression index is 32b long, sparse instructions with 16b inputs only need 1/4 of a register (8 bits per lane) to store the compression matrix.
+Because the VGPR that holds the compression index is 32b long, sparse instructions with 16b inputs only need 1/4 of a register (8 bits per lane) to store the compression index.
 Setting `CBSZ!=0` allows setting ABID to 0, 1, 2, or 3. This allows storing different compression indices in any of the 8b segments.
 
-Similarly, sparse instructions with 8b inputs only need 1/2 of a register (16 bits per lane) to store the compression matrix.
+Similarly, sparse instructions with 8b inputs only need 1/2 of a register (16 bits per lane) to store the compression indices.
 Setting `CBSZ!=0` allows setting ABID to 0 or 2, which allows choosing the compression indices from the top or bottom half of the register.
 
-This use of CBSZ and ABID modifiers for SMFMAC instructions prevents their use for broadcasting A\[\] matrix values [as described above](#example-of-using-the-cbsz-and-abid-modifiers-to-change-the-a-matrix-layout).
+This use of CBSZ and ABID modifiers for SMFMAC instructions prevents their use for broadcasting A\[\] matrix values [in the manner described above](#example-of-using-the-cbsz-and-abid-modifiers-to-change-the-a-matrix-layout).
 
-For example, the following is the same instruction as before, looking for the compression index of the 2nd row and 31st column of V\_SMFMAC\_F32\_16X16X32\_F16 on MI300, but setting CBSZ and ABID such that we are looking the upper-most bits of the compression indices' VGPR.
+For example, the following is the same instruction as before, looking for the compression index of the 2nd row and 31st column of V\_SMFMAC\_F32\_16X16X32\_F16 in MI300, but setting CBSZ and ABID such that we are looking the upper-most bits of the compression indices' VGPR.
 
 ```
 $ ./matrix_calculator.py --architecture cdna3 --instruction v_smfmac_f32_16x16x32_f16 --get-register --I-coordinate 2 --K-coordinate 31 --compression --cbsz 1 --abid 3
@@ -1159,12 +1160,12 @@ Instruction: V_SMFMAC_F32_16X16X32_F16
 K[2][31] = v0{50}.[31:28]
 ```
 
-Examples of Setting Modifiers on AMD RDNA&trade; Architectures
--------------------------------------------------------------------------------------
+Examples of Setting Modifiers in the AMD RDNA&trade; 3 Architecture
+-------------------------------------------------------------------------------------------------------
 AMD Radeon&trade; GPUs that use the RDNA 3 architecture allow setting modifier fields that change how the matrix multiplication instructions access data out of registers.
 Examples of using these fields, `OPSEL`, and `NEG`, are shown below.
 
-### Example of Using the OPSEL Modifier to Change the C and D Matrix Storage
+### Example of Using the OPSEL Modifier to Change the C and D Matrix Storage in the AMD RDNA&trade; 3 Architecture
 Some instructions in the AMD RDNA&trade; 3 architecture allow the elements in the C\[\] and D\[\] matrices to be 16-bit values.
 The format of these matrices uses 16 bits out of each 32-bit register to store these values.
 These instructions will read only half of each C\[\] input register and write to only half of each D\[\] output register.
@@ -1176,7 +1177,7 @@ Setting `OPSEL[2]=1` will cause the WMMA instruction to read from the top half o
 This tool allows setting of this field using the `--opsel` flag for architecture and instructions that support this modifier.
 Legal values for this option are `--opsel 0`, which indicates `OPSEL[2]=0`, and `--opsel 4`, which indicates `OPSEL[2]=1`.
 
-The following is an example of the register layout for the matrix D of the V\_WMMA\_F16\_16X16X16_f16 instruction in the RDNA&trade; 3 architecture without the OPSEL modifier set:
+The following is an example of the register layout for the matrix D of the V\_WMMA\_F16\_16X16X16\_f16 instruction in the RDNA 3 architecture without the OPSEL modifier set:
 ```
 $ ./matrix_calculator.py --architecture rdna3 --instruction v_wmma_f16_16x16x16_f16 --register-layout --D-matrix
 Architecture: RDNA3
@@ -1220,7 +1221,7 @@ Instruction: V_WMMA_F16_16X16X16_F16
 
 In the above case, because `OPSEL[2]=0`, only the bottom half of each register (bits 15:0) is used.
 
-The following is an example of the register layout for the matrix D of the V\_WMMA\_F16\_16X16X16_f16 instruction in the RDNA&trade; 3 architecture without the OPSEL modifier set:
+The following is an example of the register layout for the matrix D of the V\_WMMA\_F16\_16X16X16\_f16 instruction in the RDNA 3 architecture without the OPSEL modifier set:
 ```
 $ ./matrix_calculator.py --architecture rdna3 --instruction v_wmma_f16_16x16x16_f16 --register-layout --D-matrix --opsel 4
 Architecture: RDNA3
@@ -1273,16 +1274,16 @@ For floating point WMMA instructions, setting the middle bit of NEG will negate 
 For floating point WMMA instructions, setting the highest-order bit of NEG will negate Src3, the values of the C matrix, while setting the highest-order bit of NEG_HI will take the absolute value of the C matrix entry.
 Any of the bits may be set at the same time; when `NEG[2]` and `NEG_HI[2]` are both set, the absolute value is calculated before the negation.
 
-For integer WMMA instructions, the two lower-order bits of `NEG` are used to control whether the values in the A\[] and B\[] matrices are treated as unsigned or signed integers.
+For integer WMMA instructions, the two lower-order bits of `NEG` are used to control whether the values in the A\[\] and B\[\] matrices are treated as unsigned or signed integers.
 `NEG[2]` and the entire `NEG_HI` modifier may not be used to negate the A\[] or B\[] matrices for integer WMMA instructions, and they should be set to 0.
 
 This tool allows setting the `NEG` field using the `--neg` flag for architectures and instructions that support this modifier.
 The  `--neg_hi` flag is used to set the `NEG_HI` field.
 Because these are 3-bit fields, legal values for this option are integers between 0 and 7, inclusive.
-See [the later section on instruction encodings](#details-of-the-vop3p-matrix-multiplication-instruction-encoding-for-amd-rdna-3-architectures) for how the `NEG` field and `NEG_HI` fields interact.
-This tool does not let users manually change the NEG_HI field.
+See [the later section on instruction encodings](#details-of-the-vop3p-matrix-multiplication-instruction-encoding-in-the-amd-rdna-3-architecture) for how the `NEG` field and `NEG_HI` fields interact.
+This tool does not let users manually change the `NEG_HI` field.
 
-The following is an example that requests the matrix layout of the matrix B for the V\_WMMA\_F32\_16X16X16_F16 instruction on RDNA 3 architecture, with the `NEG` and `NEG_HI` value of 6.
+The following is an example that requests the matrix layout of the matrix B for the V\_WMMA\_F32\_16X16X16\_F16 instruction in the RDNA 3 architecture, with the `NEG` and `NEG_HI` value of 6.
 Because the value 6 has the middle bit set, the values of the B\[\] matrix are returned with a negative sign to indicate that their values will be negated by the instruction.
 
 ```
@@ -1358,12 +1359,11 @@ Instruction: V_WMMA_F32_16X16X16_F16
 +--------+-------------+--------------+-------------+--------------+-------------+--------------+-------------+--------------+-------------+--------------+-------------+--------------+-------------+--------------+-------------+--------------+
 ```
 
-
 Details of AMD Matrix Multiplication Instruction Encodings
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 This section details the encodings used by matrix multiplication instructions in AMD accelerators.
 
-### Details of the VOP3P-MAI Matrix Multiplication Instruction Encoding for AMD CDNA&trade; 1 - CDNA 3 Architectures
+### Details of the VOP3P-MAI Matrix Multiplication Instruction Encoding in the AMD CDNA&trade; 1 - CDNA 3 Architectures
 In the CDNA 1, 2, and 3 architectures, matrix multiplications instructions contain "MFMA", or matrix fused multiply add, in their mnemonics.
 Instructions that execute matrix multiplication on 4:2 structured sparse matrices contain "SMFMAC", or sparse matrix fused multiply accumulate, in their mnemonics.
 This section details the instruction encoding and the configuration fields for these instructions.
@@ -1373,8 +1373,8 @@ VOP3P-MAI is a subset of the VOP3P (**V**ector **Op** with **3** Inputs, Doing *
 The differentiator between these spaces is the upper-most bit in the 7-bit opcode field is always 0 in traditional VOP3P, while it is always 1 in VOP3P-MAI.
 This is labelled as bit 54 in the chart below, and bit 22 in the AMD ISA guides.
 
-The reason for this nomenclature difference is because the VOP3P-MAI is a 64b opcode, where bits [63:32] are held at bytes address X, and [31:0] are at bytes address X+4.
-This 64b encoding space is how AMD's software tools, such as `roc-obj` and LLVM decode these 64b instructions.
+The reason for this nomenclature difference is because the VOP3P-MAI is a 64b opcode, where bits \[63:32\] are held at bytes address X, and \[31:0\] are at bytes address X+4.
+This 64b encoding space is how AMD's software tools, such as `llvm-objdump`, decode these 64b instructions.
 Because the software tools will display these as a 64b number, we illustrate the encoding as such in this section.
 
 If looking at these opcodes from the viewpoint of a little-endian architecture that primarily works on 4-byte values, one would swap bits 63:32 with bits 31:00.
@@ -1424,12 +1424,12 @@ The following fields are illustrated:
         * 248: 1/(2*pi)
         * 249-255: Reserved
         * 256-511: Registers 0-255
-    * Only 256 registers can be addressed by this field. The choice of ArchVGPR and AccVGPR is controlled by ACC[0], bit 27.
+    * Only 256 registers can be addressed by this field. The choice of ArchVGPR and AccVGPR is controlled by ACC\[0\], bit 27.
 * Vsrc1
     * Bits 17:9
     * Encoding for the B\[\] input matrix
     * This is a 9-bit field that uses the same encoding described above for Vsrc0
-    * Only 256 registers can be addressed by this field. The choice of ArchVGPR and AccVGPR is controlled by ACC[1], bit 28.
+    * Only 256 registers can be addressed by this field. The choice of ArchVGPR and AccVGPR is controlled by ACC\[1\], bit 28.
 * Vsrc2
     * Bits 26:18
     * Encoding for the C\[\] input matrix
@@ -1444,7 +1444,7 @@ The following fields are illustrated:
     * Configures the B-matrix Lane Group Pattern parameter
         * Described in detail in the section: [Example of Using the BLGP Modifier to Change the B Matrix Layout](#example-of-using-the-blgp-modifier-to-change-the-b-matrix-layout)
     * For FP64 instructions in the CDNA 3 architecture, this field is used to negate input matrix values.
-        * Described in detail in the section: [Using the BLGP Modifier to Negate Input Matrices on CDNA&trade; 3 Architectures](#using-the-blgp-modifier-to-negate-input-matrices-on-cdna-architectures)
+        * Described in detail in the section: [Example of Using the BLGP Modifier to Negate Input Matrices in the CDNA™ 3 Architecture](#example-of-using-the-blgp-modifier-to-negate-fp64-input-matrices-in-the-cdna-3-architecture)
 * Vdst
     * Bits 39:32
     * Encoding for the D\[\] output matrix
@@ -1461,7 +1461,7 @@ The following fields are illustrated:
 * ACC\_CD
     * Single bit that controls whether the C\[\] and D\[\] matrices use the ArchVGPR space (when set to 0) or the AccVGPR space (when set to 1)
 
-### Details of the VOP3P Matrix Multiplication Instruction Encoding for AMD RDNA&trade; 3 Architectures
+### Details of the VOP3P Matrix Multiplication Instruction Encoding in the AMD RDNA&trade; 3 Architecture
 In the RDNA 3 architecture, matrix multiplications instructions contain "WMMA", or wave matrix multiply accumulate, in their mnemonics.
 This section details the instruction encoding and the configuration fields for these instructions.
 
@@ -1469,8 +1469,8 @@ These operations are encoded in the VOP3P (**V**ector **Op** with **3** Inputs, 
 This field contains the 6-bit value `110011b` in bits 63:58, as labeled in the figure below.
 This 6-bit value is listed as bits 31:26 in the AMD ISA guides.
 
-The reason for this nomenclature difference is because the VOP3P is a 64b opcode, where bits [63:32] are held at bytes address X, and [31:0] are at bytes address X+4.
-This 64b encoding space is how AMD's software tools, such as `roc-obj` and LLVM decode these 64b instructions.
+The reason for this nomenclature difference is because the VOP3P is a 64b opcode, where bits \[63:32\] are held at bytes address X, and \[31:0\] are at bytes address X+4.
+This 64b encoding space is how AMD's software tools, such as `llvm-objdump`, decode these 64b instructions.
 Because the software tools will display these as a 64b number, we illustrate the encoding as such in this section.
 
 If looking at these opcodes from the viewpoint of a little-endian architecture that primarily works on 4-byte values, one would swap bits 63:32 with bits 31:00.
@@ -1485,13 +1485,13 @@ The following illustrates the 64b VOP3P instruction format.
 |                       |                       |                       |                       |
 |                 |        |                    |CL|OP|        |        |                       |
 | 1  1  0  0  1  1| 0  0  0|    7-bit opcode    |AM|SH|  OPSEL | NEG_HI |          Vdst         |
-|                 |        |                    |P |I0|        |        |                       |
+|                 |        |                    |P |I2|        |        |                       |
 -------------------------------------------------------------------------------------------------
 |31|30|29|28|27|26|25|24|23|22|21|20|19|18|17|16|15|14|13|12|11|10|09|08|07|06|05|04|03|02|01|00|
 |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
 |                       |                       |                       |                       |
 |        |OPSEL|                          |                          |                          |
-|   NEG  |HI_12|           Vsrc2          |           Vsrc1          |           Vsrc0          |
+|   NEG  |HI_01|           Vsrc2          |           Vsrc1          |           Vsrc0          |
 |        |     |                          |                          |                          |
 -------------------------------------------------------------------------------------------------
 ```
@@ -1532,6 +1532,9 @@ The following fields are illustrated:
         * 256-511: Registers 0-255
 * OPSEL\_HI
     * Bits 46, 28:27
+        * Bit 46 is OPSEL_HI bit 2
+        * Bit 28 is OPSEL_HI bit 1
+        * Bit 27 is OPSEL_HI bit 0
     * Unused by WMMA instructions. Set to 0.
 * NEG
     * Bits 31:29
@@ -1572,7 +1575,7 @@ The following fields are illustrated:
     * This field does not affect floating point WMMA operations.
 
 Further Materials
--------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------------------------
 Further information about the MFMA and WMMA instructions, their data layout, and their capabilities can be found in AMD manuals, code repositories, and blog posts.
 This section is meant to contains a list of as many of these documents as possible.
 
@@ -1588,7 +1591,7 @@ This section is meant to contains a list of as many of these documents as possib
         * Public ISA Guide for AMD Radeon&trade; GPUs using the RNDA3 ISA
 * AMD Blog Posts
     * <https://gpuopen.com/learn/amd-lab-notes/amd-lab-notes-matrix-cores-README/>
-        * AMD lab notes on AMD Matrix Cores, which covers the use of MFMA instructions on CDNA 1 and CDNA 2 accelerators
+        * AMD lab notes about AMD Matrix Cores, which covers the use of MFMA instructions in CDNA 1 and CDNA 2 accelerators
     * <https://gpuopen.com/learn/wmma_on_rdna3/>
         * "How to accelerate AI applications on RDNA 3 using WMMA", which covers the use of WMMA instructions on RDNA3 GPUs
 * AMD Matrix Code Repositories
@@ -1600,5 +1603,5 @@ This section is meant to contains a list of as many of these documents as possib
         * This library is the recommended path for developers to access these matrix acceleration instructions in the majority of cases
 
 Trademark Attribution
--------------------------------------------------------------------------------------
-&copy; 2022-2024 Advanced Micro Devices, Inc. All rights reserved. AMD, the AMD Arrow logo, AMD CDNA, Instinct, Radeon, RDNA, and combinations thereof are trademarks of Advanced Micro Devices, Inc. in the United States and/or other jurisdictions. Other names are for informational purposes only and may be trademarks of their respective owners.
+-------------------------------------------------------------------------------------------------------
+&copy; 2022-2025 Advanced Micro Devices, Inc. All rights reserved. AMD, the AMD Arrow logo, AMD CDNA, Instinct, Radeon, RDNA, and combinations thereof are trademarks of Advanced Micro Devices, Inc. in the United States and/or other jurisdictions. Other names are for informational purposes only and may be trademarks of their respective owners.

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Command line parameters are case sensitive, but inputs for the command-line para
 * `--architecture {arch name}` (or `-a {arch name}`): This parameter chooses which AMD architecture to use for further calculations. This must be set for every other action in the application. Legal inputs are:
     * `CDNA`, `CDNA1`, `gfx908`, `arcturus`, or `MI100`: The AMD Instinct&trade; MI100 series of accelerators
     * `CDNA2`, `gfx90a`, `aldebaran`, `MI200`, `MI210`, `MI250`, or `MI250X`: The AMD Instinct MI200 series of accelerators, including AMD Instinct MI210, AMD Instinct MI250, and AMD Instinct MI250X
-    * `CDNA3`, `gfx940`, `gfx941`, `gfx942`, `aqua_vanjaram`, `MI300`, `MI300A`, or `MI300X`: The AMD Instinct MI300 series of accelerators
-    * `RDNA3`, `gfx1100`, `gfx1101`, `gfx1102`, `gfx1103`, `gfx1150`, or `gfx1151`: The AMD Radeon&trade; RDNA&trade; 3 series of GPUs
+    * `CDNA3`, `gfx940`, `gfx941`, `gfx942`, `aqua_vanjaram`, `MI300`, `MI300A`, `MI300X`, or `MI325X`: The AMD Instinct MI300 series of accelerators
+    * `RDNA3`, `gfx1100`, `gfx1101`, `gfx1102`, `gfx1103`, `gfx1150`, `gfx1151`, `gfx1152`, `gfx1153`: The AMD Radeon&trade; RDNA&trade; 3 series of GPUs
 * `--list-instructions` (or `-L`): This parameter will print the supported matrix multiplication instructions for the chosen architecture and exit the application.
 * `--instruction {instruction mnemonic}` (or `-i {instruction mnemonic}`): This parameter chooses which instruction, from the list of legal matrix multiplication instructions in the chosen architecture, to use for the calculations in this tool.
 

--- a/matrix_calculator.py
+++ b/matrix_calculator.py
@@ -71,7 +71,7 @@ except ImportError:
     from typing_extensions import TypedDict
 from tabulate import tabulate
 
-VERSION = "1.2.4"
+VERSION = "1.2.5"
 
 # Dictionary of possible names for the various supported architectures
 dict_isas = {
@@ -94,6 +94,7 @@ dict_isas = {
     'mi300'            : 'cdna3',
     'mi300a'           : 'cdna3',
     'mi300x'           : 'cdna3',
+    'mi325x'           : 'cdna3',
     'aqua_vanjaram'    : 'cdna3',
     'rdna3'            : 'rdna3',
     'gfx1100'          : 'rdna3',
@@ -101,7 +102,9 @@ dict_isas = {
     'gfx1102'          : 'rdna3',
     'gfx1103'          : 'rdna3',
     'gfx1150'          : 'rdna3',
-    'gfx1151'          : 'rdna3'
+    'gfx1151'          : 'rdna3',
+    'gfx1152'          : 'rdna3',
+    'gfx1153'          : 'rdna3'
 }
 
 class MatrixNumericalType(TypedDict):

--- a/matrix_calculator.py
+++ b/matrix_calculator.py
@@ -70,7 +70,7 @@ except ImportError:
     from typing_extensions import TypedDict
 from tabulate import tabulate
 
-VERSION = "1.1.1"
+VERSION = "1.1.2"
 
 # Dictionary of possible names for the various supported architectures
 dict_isas = {
@@ -2463,7 +2463,7 @@ def print_arch_inst(arch: str, inst_name: str) -> None:
     print(f"Instruction: {inst_name.upper()}", flush=True)
 
 def get_data_size(data_type: str) -> int:
-    """ Returns the size of a data type, in bits
+    """ Returns the size of a data type, in bits.
 
     Args:
         data_type: string that contains the data type, from the dict_math_types dictionary keys
@@ -2474,7 +2474,7 @@ def get_data_size(data_type: str) -> int:
     return dict_math_types[data_type]['size']
 
 def get_type_desc(data_type: str) -> str:
-    """ Returns the pretty print string that describes a data type
+    """ Returns the pretty print string that describes a data type.
 
     Args:
         data_type: string that contains the data type, from the dict_math_types dictionary keys
@@ -2498,8 +2498,8 @@ def parse_and_run() -> int:
     recommendations if they are not.
 
     Returns:
-        An integer to pass back to the command-line caller of this application.
-        0 means that things passed successfully.
+        An integer to pass back to the command-line caller of this application
+        0 means that things passed successfully
         -1 means there was an internal error in the application
         -2 means there was a bad command line parameter passed to the application
     """
@@ -3077,7 +3077,7 @@ class InstCalc(metaclass=ABCMeta):
             data_size: integer holding the size of this regno's data, in bits.
             sparse: True if this register is working on a structured sparsity input register
             compression_index: True if this register holds the compression index for a
-                structured sparsity instruction.
+                structured sparsity instruction
             k_cbsz: When working on compression indices, a non-zero CBSZ value will cause
                 different register locations to be used for the compression index. As such,
                 when passing in compression_index=True, this integer field holds the
@@ -3098,7 +3098,7 @@ class InstCalc(metaclass=ABCMeta):
                 two contiguous numbers together, and so may be e.g. "1:0" to show that this
                 single regno is using both VGPR1 and VGPR0.
             '.c' is an optional extension that, when a value accesses a subset of a VGPR.
-                e.g., when accessing the bottom half of a register, it would be .[15:0]
+                e.g., when accessing the bottom half of a register, it would be .[15:0].
         """
         this_str = "v"
         if not compression_index:
@@ -3164,13 +3164,13 @@ class InstCalc(metaclass=ABCMeta):
 
         Args:
             reg: string holding a register number, of the form Va.c.
-                'V' is a constant character that shows this is a vector register
+                'V' is a constant character that shows this is a vector register.
                 'a' is the actual register number. For example, if an instruction has 8 VGPRs,
                     then this value would be between 0-7. When this is a 64b register, this
                     will combine two contiguous numbers together, and so may be e.g. "1:0" to
                     show that this single regno is using both VGPR1 and VGPR0.
                 '.c' is an optional extension that, when a value accesses a subset of a VGPR.
-                    e.g, when accessing the bottom half of a register, it would be .[15:0]
+                    e.g, when accessing the bottom half of a register, it would be .[15:0].
             lane: integer holding the lane number to combine with the above reg
 
         Returns:
@@ -3232,7 +3232,7 @@ class InstCalc(metaclass=ABCMeta):
 
         Args:
             block: an integer representing the original block of A that would be used
-                in a calculation.
+                in a calculation
             cbsz: an integer that contains the instruction's CBSZ value
             abid: an integer that contains the instruction's ABID value
 
@@ -3264,7 +3264,7 @@ class InstCalc(metaclass=ABCMeta):
 
         Args:
             lane: an integer representing the original lane of B that would be used
-                in a calculation.
+                in a calculation
             blgp: an integer that contains the instruction's BLGP value
 
         Returns:
@@ -3330,8 +3330,8 @@ class InstCalc(metaclass=ABCMeta):
             Based on the matrix and requested coordinates, return three things in a tuple:
             1. String requested element name, in the format A[i][k], B[k][j], or C[i][j]
             2. String register name that holds the element, in the format V#.[bits]
-            3. List of integers, containing the lane numbers within that register that
-                hold the element.
+            3. List of integers containing the lane numbers within that register that
+                hold the element
             Tuple: (matrix entry, register holding that entry, lanes within that register)
         """
 
@@ -3354,7 +3354,7 @@ class InstCalc(metaclass=ABCMeta):
             b_lanes: list of integers containing all the lanes of B to query
 
         Returns:
-            Integer from the available lanes of B that match the requested lane of A.
+            Integer from the available lanes of B that match the requested lane of A
         """
 
     @staticmethod
@@ -3365,14 +3365,14 @@ class InstCalc(metaclass=ABCMeta):
         absolute values, depending on the input matrix and the 'negate' structure.
 
         Args:
-            reg: string that lists the register that holds this matrix entry.
-                String should contain [15:0] or [31:16] if the entry is in the lower
+            reg: string that lists the register that holds this matrix entry
+                This string should contain [15:0] or [31:16] if the entry is in the lower
                 or upper halves, respectively.
             mat_val: string that contains the matrix entry value, which this function
-                may add "-" to negate, and "|mat_val|" to indicate absolute value.
+                may add "-" to negate, and "|mat_val|" to indicate absolute value
             matrix: string name of the matrix this entry comes from
             negate: dictionary of matrix names to bools that indicate whether to
-                negate and absolute-val entries from this matrix.
+                negate and absolute-val entries from this matrix
 
         Returns:
             String that may just be mat_val (if no negation or abs-val), -mat_val
@@ -3405,7 +3405,7 @@ class InstCalc(metaclass=ABCMeta):
                 False causes the string to contain the VGPRs and lanes that make up the
                 A[], B[], and C[] matrices that go into the calculation.
             negate: dictionary of matrix names to bools that indicate whether to
-                negate and absolute-val entries from this matrix.
+                negate and absolute-val entries from this matrix
             cbsz: integer containing this instruction's CBSZ modifier
             abid: integer containing this instruction's ABID modifier
             blgp: integer containing this instruction's BLGP modifier
@@ -3413,7 +3413,7 @@ class InstCalc(metaclass=ABCMeta):
 
         Returns:
             A string containing a mathematical formula of the matrix entries or register-lanes
-            that went into calculating the requested D matrix entry.
+            that went into calculating the requested D matrix entry
         """
         inst_info = self.inst_info
         # Matrix being sent in will look like D[i][j].Bb, where the ".Bb" is optional.
@@ -3497,14 +3497,14 @@ class InstCalc(metaclass=ABCMeta):
                     [31:24]: the most significant 8b of a 32b register
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             out_calc: True if, when printing the register location for the D
                 output matrix entry, you desire to also print the register
                 locations of the A, B, and C matrices that went into the
-                calculation of the output.
+                calculation of the output
             negate: dictionary of matrix names to bools that indicate whether to
-                negate and absolute-val entries from this matrix.
+                negate and absolute-val entries from this matrix
             i: integer coordinate for the query of the matrix row for A, C, D, & K matrices
             j: integer coordinate for the query of the matrix column for the B, C, & D matrices
             k: integer coordinate for the query of the A & K column or B row
@@ -3574,15 +3574,15 @@ class InstCalc(metaclass=ABCMeta):
         So V0{17}.[23:16] -> A[i][k] for whichever values of i and k.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             cbsz: integer value of the instruction's CBSZ modifier
             abid: integer value of the instruction's ABID modifier
             blgp: integer value of the instruction's BLGP modifier
             opsel: integer value of the instruction's OPSEL modifier
 
         Returns:
-            Dictionary of register-lane string keys that map to lists of matrix entry strings.
+            Dictionary of register-lane string keys that map to lists of matrix entry strings
             If the VGPR is used for multiple matrix entries (e.g., due to modifiers pushing the
             VGPR's data to multiple matrix inputs), the list of strings may be >1 entry.
         """
@@ -3622,7 +3622,7 @@ class InstCalc(metaclass=ABCMeta):
     # this to be a method and have access to self variables.
     #pylint: disable=no-self-use
     def _calculate_initial_regno_offset(self, matrix: str, opsel: int) -> int:
-        """ Calculates an offset into a register slot based on OPSEL
+        """ Calculates an offset into a register slot based on OPSEL.
 
         On some architectures, partial registers (such as a 16b output in a 32b register)
         aren't tightly packed. For example, "lower" or "upper halves may be skipped
@@ -3638,8 +3638,8 @@ class InstCalc(metaclass=ABCMeta):
         function.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             opsel: integer value of the instruction's OPSEL modifier
 
         Returns:
@@ -3668,8 +3668,8 @@ class InstCalc(metaclass=ABCMeta):
         function.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             gpr_ratio: the number of regnos in each GPR
 
         Returns:
@@ -3697,13 +3697,13 @@ class InstCalc(metaclass=ABCMeta):
         of whether the requested register was Vn+1 or Vn.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             out_calc: True if, when printing the matrix entry for the D output
                 location, you desire to also print the matrix entries of the A, B,
-                and C matrices that went into the calculation of the output.
+                and C matrices that went into the calculation of the output
             negate: dictionary of matrix names to bools that indicate whether to
-                negate and absolute-val entries from this matrix.
+                negate and absolute-val entries from this matrix
             reg: integer value of the register number to request
             lane: integer value of the lane to request
             cbsz: integer value of the instruction's CBSZ modifier
@@ -3833,13 +3833,13 @@ class InstCalc(metaclass=ABCMeta):
         This function calculates this scaling value based on the matrix and type of instruction.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
 
         Returns:
             Floating point scaling calculation, e.g. a value of 0.5 indicates that there are
             two entries in each "regno" slot, so only move the regno value by 1 only after
-            printing twice.
+            printing twice
         """
         if ((self.inst_info['sparse'] and matrix.lower() == 'a') or matrix.lower() == 'k'):
             ret_this = 0.5
@@ -3861,7 +3861,7 @@ class InstCalc(metaclass=ABCMeta):
 
         Args:
             output_type: string that indicates the type of output, from the list of
-                csv, markdown, asciidoc, or grid.
+                csv, markdown, asciidoc, or grid
         """
         if str(output_type.lower().strip()) == str("csv"):
             join_char = ";"
@@ -3881,7 +3881,7 @@ class InstCalc(metaclass=ABCMeta):
         Args:
             table_to_print: List of list of strings, which makes up a 2D table to print
             output_type: string that indicates the type of output, from the list of
-                csv, markdown, asciidoc, or grid.
+                csv, markdown, asciidoc, or grid
 
         Returns:
             String returned from tabulate, ready to print
@@ -3923,10 +3923,10 @@ class InstCalc(metaclass=ABCMeta):
                     [31:24]: the most significant 8b of a 32b register
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             requested_output: string that indicates the type of output, from the list of
-                csv, markdown, asciidoc, or grid.
+                csv, markdown, asciidoc, or grid
             negate: dictionary of matrix names to bools that indicate whether to
                 negate and absolute-val entries from this matrix.
             cbsz: integer value of the instruction's CBSZ modifier
@@ -3935,7 +3935,7 @@ class InstCalc(metaclass=ABCMeta):
             opsel: integer value of the instruction's OPSEL modifier
             transpose: boolean set to true to cause the matrix to be printed transposed
             print_blocks: boolean set to true if this architecture and instruction
-                should print the word "Block #" above each block of the matrix.
+                should print the word "Block #" above each block of the matrix
         """
         inst_info = self.inst_info
         M = inst_info['m']
@@ -4046,19 +4046,19 @@ class InstCalc(metaclass=ABCMeta):
         show rows as columns and vice versa.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
             requested_output: string that indicates the type of output, from the list of
-                csv, markdown, asciidoc, or grid.
+                csv, markdown, asciidoc, or grid
             negate: dictionary of matrix names to bools that indicate whether to
-                negate and absolute-val entries from this matrix.
+                negate and absolute-val entries from this matrix
             cbsz: integer value of the instruction's CBSZ modifier
             abid: integer value of the instruction's ABID modifier
             blgp: integer value of the instruction's BLGP modifier
             opsel: integer value of the instruction's OPSEL modifier
             transpose: boolean set to true to cause the matrix to be printed transposed
             contig_values: an integer that defines the number of contiguous values of a
-                register that are used to hold unique values of a matrix.
+                register that are used to hold unique values of a matrix
         """
         inst_info = self.inst_info
         M = inst_info['m']
@@ -4149,12 +4149,12 @@ class InstCalc(metaclass=ABCMeta):
         """ Calculates the number of GPRs needed to hold a matrix.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, or k (for the compression index of sparse matrices).
             in_lanes: an integer that defines the number of contiguous lanes that are used to hold
                 values of a matrix. If this is not passed in, the argument is matched to the
                 wavefront size of the target architecture.
-            out_size: The number of bits used to hold output values for this instruction.
+            out_size: The number of bits used to hold output values for this instruction
                 For instance: some devices may store 16b values into either the low or high
                 half of a 32b output register. These architectures would need out_type=32.
                 If this is not passed in, the argument is matched to the actual instruction's
@@ -4189,7 +4189,7 @@ class InstCalc(metaclass=ABCMeta):
     def _coord_to_input_reg_eqn(self, matrix: str) ->str:
         """ Returns formula for mapping a matrix coordinate to its input register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the input register that holds a particular entry in the matrix from its
         i/j/k/block coordinates.
 
@@ -4197,8 +4197,8 @@ class InstCalc(metaclass=ABCMeta):
         Should be filled in by the architecture child classes.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, or k (for the compression index of sparse matrices).
 
         Returns:
             String that contains the simple formula mapping coordinates to input registers
@@ -4208,7 +4208,7 @@ class InstCalc(metaclass=ABCMeta):
     def _coord_to_output_reg_eqn(self) -> str:
         """ Returns formula for mapping a matrix coordinate to its output register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the output register that holds a particular entry in the matrix from its
         i/j/k/block coordinates.
 
@@ -4222,13 +4222,13 @@ class InstCalc(metaclass=ABCMeta):
     def __coord_to_reg_eqn(self, matrix: str) -> str:
         """ Returns formula for mapping a matrix coordinate to its register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the register that holds a particular entry in the matrix from its i/j/k/block
         coordinates.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, or k (for the compression index of sparse matrices).
 
         Returns:
             String that contains the simple formula mapping coordinates to registers
@@ -4247,7 +4247,7 @@ class InstCalc(metaclass=ABCMeta):
     def _coord_to_lane_eqn(self, matrix: str) -> str:
         """ Returns formula for mapping a matrix coordinate to its wavefront lane.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the lane that holds a particular entry in the matrix from its i/j/k/block
         coordinates.
 
@@ -4255,8 +4255,8 @@ class InstCalc(metaclass=ABCMeta):
         Should be filled in by the architecture child classes.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, or k (for the compression index of sparse matrices).
 
         Returns:
             String that contains the simple formula mapping coordinates to lanes
@@ -4265,15 +4265,15 @@ class InstCalc(metaclass=ABCMeta):
     def _print_element_to_register_eqn(self, block: str = "Unknown") -> None:
         """ Prints formula for matrix entry to GPR and lane mapping.
 
-        Print out the simple formulae to calculate the the mapping of a matrix element to its
+        Prints out the simple formulae to calculate the the mapping of a matrix element to its
         register and lane.
 
         Will always print A[], B[], and D[]. If the instruction allows C[] matrices, then it will
-        print D[] as "C or D[i][j]". For sparse instructions, may also print the compression
+        print D[] as "C or D[i][j]". For sparse instructions, will also print the compression
         matrix.
 
         Args:
-            block: string that contains text to place in the matrix entry map for blocks.
+            block: string that contains text to place in the matrix entry map for blocks
                 For instance, pass ".block" if an architecture should print an entry as
                 A[i][k].block. Pass "" to just print A[i][k].
         """
@@ -4298,13 +4298,9 @@ class InstCalc(metaclass=ABCMeta):
         calculate the A matrix's i coordinate or the B matrix's j coordinate based on the
         register and lane.
 
-        Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a and b
-
         Returns:
             A string which contains the equation to calculate the i or j coordinate for
-            an input matrix held by a particular register and lane combination.
+            an input matrix held by a particular register and lane combination
         """
         return f"(lane % {self.inst_info['m']})"
 
@@ -4318,12 +4314,12 @@ class InstCalc(metaclass=ABCMeta):
         child classes overloading this function.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, c, d, or k (for the compression index of sparse matrices).
 
         Returns:
             A string which contains the equation to calculate the i coordinate for
-            an input matrix held by a particular register and lane combination.
+            an input matrix held by a particular register and lane combination
         """
         ret_string = "Unknown" # c and d matrix must be handled by child classes
         if matrix.lower() == 'a':
@@ -4339,13 +4335,9 @@ class InstCalc(metaclass=ABCMeta):
         equation which lets users calculate the j coordinate based on the register and lane.
         Targets a particular instruction, and does not handle modifiers.
 
-        Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                c and d
-
         Returns:
             A string which contains the equation to calculate the j coordinate held by a
-            particular output register and lane combination.
+            particular output register and lane combination
         """
         return f"(lane % {self.inst_info['m']})"
 
@@ -4357,12 +4349,12 @@ class InstCalc(metaclass=ABCMeta):
         Targets a particular instruction, and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                b, c, and d
+            matrix: string that contains the name of the matrix
+                Legal values are b, c, and d.
 
         Returns:
             A string which contains the equation to calculate the j coordinate held by a
-            particular register and lane combination.
+            particular register and lane combination
         """
         if matrix.lower() == 'b':
             ret_string = self.__reg_lane_to_input_ij_coord_eqn()
@@ -4382,12 +4374,12 @@ class InstCalc(metaclass=ABCMeta):
         method and must be filled in by child classes.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, and k (for the compression index of sparse matrics).
 
         Returns:
             A string which contains the equation to calculate the k coordinate held by a
-            particular register and lane combination.
+            particular register and lane combination
         """
 
     @abstractmethod
@@ -4402,12 +4394,12 @@ class InstCalc(metaclass=ABCMeta):
         method and must be filled in by child classes.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
 
         Returns:
             A string which contains the equation to calculate the block held by a particular
-            register and lane combination.
+            register and lane combination
         """
 
     @staticmethod
@@ -4445,7 +4437,7 @@ class InstCalc(metaclass=ABCMeta):
         put them into output matrix locations.
 
         Args:
-            print_block: True if this equation should print information about blocks.
+            print_block: True if this equation should print information about blocks
         """
         inst_info = self.inst_info
         sparse_op = inst_info['sparse']
@@ -4478,7 +4470,7 @@ class InstCalc(metaclass=ABCMeta):
 
         Args:
             encoding_name: String containing the name of the encoding format for the
-                current architecture.
+                current architecture
                 Defaults to "Unknown", and should either be filled in by child class
                 specializations of this function or directly by callers.
         """
@@ -4505,7 +4497,7 @@ class InstCalc(metaclass=ABCMeta):
         The instruction and architecture are part of the class.
 
         Args:
-            cu_name: string that contains the name of the compute unit on the target arch.
+            cu_name: string that contains the name of the compute unit on the target arch
                 Different architectures may use e.g., CU, or WGP, or some other name.
                 Defaults to "Unknown", and should either be filled in by child class
                 specializations of this function or directly by callers.
@@ -4543,10 +4535,10 @@ class InstCalc(metaclass=ABCMeta):
         instruction on a target architecture. Some architectures support more than one
         wavefront size. In that case, print out the register usage for each wavefront size.
         This is needed because different wavefront sizes can cause different GPR usage for
-        the same matris size.
+        the same matrix size.
 
         Args:
-            wave_sizes: a tuple of wavefront sizes to use to print this info.
+            wave_sizes: a tuple of wavefront sizes to use to print this info
                 Defaults to an empty tuple, and should either be filled in by child class
                 specializations of this function or directly by callers.
         """
@@ -4594,7 +4586,7 @@ class InstCalc(metaclass=ABCMeta):
 
         Args:
             encoding_name: String containing the name of the encoding format for the
-                current architecture.
+                current architecture
                 Defaults to "Unknown", and should either be filled in by child class
                 specializations of this function or directly by callers.
         """
@@ -4646,7 +4638,7 @@ class InstCalcGfx9(InstCalc):
         matching. It takes as an argument a list of lanes from B, and the requested
         lane of A. Returned the lane of B that is multiplied by the reuqested ane of A.
 
-        On gfx9, B matrix only has a single lane per entry, like A matrix.
+        In gfx9, B matrix only has a single lane per entry, like A matrix.
         As such, just return the first lane of B.
 
         Args:
@@ -4654,7 +4646,7 @@ class InstCalcGfx9(InstCalc):
             b_lanes: list of integers containing all the lanes of B to query
 
         Returns:
-            Integer from the available lanes of B that match the requested lane of A.
+            Integer from the available lanes of B that match the requested lane of A
         """
         del a_lane # Unused in gfx9
         return b_lanes[0]
@@ -4669,9 +4661,9 @@ class InstCalcGfx9(InstCalc):
         described in the comments within the function.
 
         Args:
-            M: integer "outer" dimension of the input matrix, in matrix entries.
+            M: integer "outer" dimension of the input matrix, in matrix entries
                 For A and K matrices, this is the height. For B matrices, this is the width
-            K: integer "inner" dimension of the input matrix, in matrix entries.
+            K: integer "inner" dimension of the input matrix, in matrix entries
                 For A and K matrices, this is the width. For B matrices, this is the height
             B: integer number of blocks in the input matrix
             i: integer location within the input matrix's "outer" dimension
@@ -4684,7 +4676,7 @@ class InstCalcGfx9(InstCalc):
             data_size: integer size of the input data, in bits
             sparse: True if this register is working on a structured sparsity input register
             compression_index: True if this register holds the compression index for a
-                structured sparsity instruction.
+                structured sparsity instruction
             k_cbsz: When working on compression indices, a non-zero CBSZ value will cause
                 different register locations to be used for the compression index. As such,
                 when passing in compression_index=True, this integer field holds the
@@ -4700,7 +4692,7 @@ class InstCalcGfx9(InstCalc):
             Based on the matrix and requested coordinates, return two things in a tuple:
             1. String register name that holds the element, in the format V#.[bits]
             2. List of integers, containing the lane numbers within that register that
-                hold the element.
+                hold the element
             Tuple: (register holding the matrix entry, lanes within that register)
         """
         # Start by calculating how many elements of the matrix there are in the
@@ -4764,7 +4756,7 @@ class InstCalcGfx9(InstCalc):
             Based on the matrix and requested coordinates, return two things in a tuple:
             1. String register name that holds the element, in the format V#.[bits]
             2. List of integers, containing the lane numbers within that register that
-                hold the element.
+                hold the element
             Tuple: (register holding the matrix entry, lanes within that register)
         """
         # The 64b output layout and 32b output layout are different.
@@ -4835,7 +4827,7 @@ class InstCalcGfx9(InstCalc):
             1. String requested element name, in the format A[i][k], B[k][j], or C[i][j]
             2. String register name that holds the element, in the format V#.[bits]
             3. List of integers, containing the lane numbers within that register that
-                hold the element.
+                hold the element
             Tuple: (matrix entry, register holding that entry, lanes within that register)
         """
         del opsel # Unused in gfx9
@@ -4895,12 +4887,12 @@ class InstCalcGfx9(InstCalc):
         """ Calculates the number of GPRs needed to hold a matrix.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, or k (for the compression index of sparse matrices).
             in_lanes: an integer that defines the number of contiguous lanes that are used to hold
-                values of a matrix. On gfx9, this is always 64, so the default of this
-                argument is 64.
-            out_size: The number of bits used to hold output values for this instruction.
+                values of a matrix
+                In gfx9, this is always 64, so the default of this argument is 64.
+            out_size: The number of bits used to hold output values for this instruction
                 For instance: some devices may store 16b values into either the low or high
                 half of a 32b output register. Some gfx9 architectures allow 64b outputs (e.g,
                 for F64 calculations). If this argument is not passed in, the function
@@ -4909,7 +4901,7 @@ class InstCalcGfx9(InstCalc):
         Returns:
             An integer that defines the number of GPRs needed to hold the requested matrix
         """
-        # On gfx9, we always use all 64 lanes for input calculations, but output sizes
+        # In gfx9, we always use all 64 lanes for input calculations, but output sizes
         # can change for 64b outputs
         if out_size is None:
             out_size = get_data_size(self.inst_info['out_type'])
@@ -4918,13 +4910,13 @@ class InstCalcGfx9(InstCalc):
     def _coord_to_input_reg_eqn(self, matrix: str) -> str:
         """ Returns formula for mapping a matrix coordinate to its input register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the input register that holds a particular entry in the matrix from its
         i/j/k/block coordinates.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, or k (for the compression index of sparse matrices).
 
         Returns:
             String that contains the simple formula mapping coordinates to input registers
@@ -4975,7 +4967,7 @@ class InstCalcGfx9(InstCalc):
     def _coord_to_output_reg_eqn(self) -> str:
         """ Returns formula for mapping a matrix coordinate to its output register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the output register that holds a particular entry in the matrix from its
         i/j/k/block coordinates.
 
@@ -5012,13 +5004,13 @@ class InstCalcGfx9(InstCalc):
     def _coord_to_lane_eqn(self, matrix: str) -> str:
         """ Returns formula for mapping a matrix coordinate to its wavefront lane.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the lane that holds a particular entry in the matrix from its i/j/k/block
         coordinates.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, or k (for the compression index of sparse matrices).
 
         Returns:
             String that contains the simple formula mapping coordinates to lanes
@@ -5068,15 +5060,15 @@ class InstCalcGfx9(InstCalc):
     def _print_element_to_register_eqn(self, block: str = ".block") -> None:
         """ Prints formula for matrix entry to GPR and lane mapping.
 
-        Print out the simple formulae to calculate the the mapping of a matrix element to its
+        Prints out the simple formulae to calculate the the mapping of a matrix element to its
         register and lane.
 
         Will always print A[], B[], and D[]. If the instruction allows C[] matrices, then it will
-        print D[] as "C or D[i][j]". For sparse instructions, may also print the compression
+        print D[] as "C or D[i][j]". For sparse instructions, will also print the compression
         matrix.
 
         Args:
-            block: string that contains text to place in the matrix entry map for blocks.
+            block: string that contains text to place in the matrix entry map for blocks
                 For instance, gfx9 uses blocks, so by default this function passes ".block"
                 to print an entry as A[i][k].block.
         """
@@ -5089,12 +5081,12 @@ class InstCalcGfx9(InstCalc):
         calculate the i coordinate for the A, C, D, or compression index matrices.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, c, d, or k (for the compression index of sparse matrices)
+            matrix: string that contains the name of the matrix
+                Legal values are a, c, d, or k (for the compression index of sparse matrices).
 
         Returns:
             A string which contains the equation to calculate the i coordinate for
-            an input matrix held by a particular register and lane combination.
+            an input matrix held by a particular register and lane combination
         """
         ret_string = super()._reg_lane_to_i_coord_eqn(matrix)
         if matrix not in ('a', 'b', 'k'):
@@ -5125,12 +5117,12 @@ class InstCalcGfx9(InstCalc):
         Targets a particular instruction, and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, and k (for the compression index of sparse matrics).
 
         Returns:
             A string which contains the equation to calculate the k coordinate held by a
-            particular register and lane combination.
+            particular register and lane combination
         """
         inst_info = self.inst_info
         in_gprs = self._get_instruction_num_gprs(matrix)
@@ -5182,7 +5174,7 @@ class InstCalcGfx9(InstCalc):
 
         Args:
             encoding_name: String containing the name of the encoding format for the
-                current architecture. Defaults to "VOP3P-MAI" on gfx9.
+                current architecture; defaults to "VOP3P-MAI" in gfx9.
         """
         super()._print_opcode(encoding_name)
         print(f"    {encoding_name} Opcode: {self.inst_info['opcode'] & 0x3f:#02x}")
@@ -5203,11 +5195,11 @@ class InstCalcGfx9(InstCalc):
         instruction on a target architecture. Some architectures support more than one
         wavefront size. In that case, print out the register usage for each wavefront size.
         This is needed because different wavefront sizes can cause different GPR usage for
-        the same matris size.
+        the same matrix size.
 
         Args:
-            wave_sizes: a tuple of wavefront sizes to use to print this info.
-                Defaults to a single truple entry of integer 64 on gfx9, because gfx9
+            wave_sizes: a tuple of wavefront sizes to use to print this info
+                Defaults to a single tuple entry of integer 64 in gfx9, because gfx9
                 only supports wave64.
         """
         super()._print_register_usage(wave_sizes)
@@ -5222,7 +5214,7 @@ class InstCalcGfx9(InstCalc):
 
         Args:
             encoding_name: String containing the name of the encoding format for the
-                current architecture. gfx9 defaults to "VOP3P-MAI".
+                current architecture; gfx9 defaults to "VOP3P-MAI".
         """
         super()._print_register_info(encoding_name)
         print("    Register capabilities:")
@@ -5250,11 +5242,12 @@ class InstCalcGfx9(InstCalc):
         and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are a, b, or k
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, or k.
 
         Returns:
             A string which contains the equation to calculate the block held by a particular
-            register and lane combination.
+            register and lane combination
         """
         inst_info = self.inst_info
         ret_string = ""
@@ -5274,11 +5267,12 @@ class InstCalcGfx9(InstCalc):
         and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are c or d
+            matrix: string that contains the name of the matrix
+                Legal values are c or d.
 
         Returns:
             A string which contains the equation to calculate the block held by a particular
-            register and lane combination.
+            register and lane combination
         """
         inst_info = self.inst_info
         ret_string = ""
@@ -5303,12 +5297,12 @@ class InstCalcGfx9(InstCalc):
         and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, d, and k (for the compression index of sparse matrics)
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, d, and k (for the compression index of sparse matrics).
 
         Returns:
             A string which contains the equation to calculate the block held by a particular
-            register and lane combination.
+            register and lane combination
         """
         if matrix.lower() in ('a', 'b'):
             ret_string = self.__reg_lane_to_input_block_eqn()
@@ -5324,9 +5318,9 @@ class InstCalcGfx9(InstCalc):
         The instruction and architecture are part of the class.
 
         Args:
-            cu_name: string that contains the name of the compute unit on the target arch.
+            cu_name: string that contains the name of the compute unit on the target arch
                 Different architectures may use e.g., CU, or WGP, or some other name.
-                Defaults to "CU" on gfx9.
+                Defaults to "CU" in gfx9.
         """
         super()._print_execution_statistics(cu_name)
 
@@ -5338,18 +5332,18 @@ class InstCalcGfx9(InstCalc):
         set modifiers like CBSZ/ABID or BLGP to quickly unpack values from registers to
         put them into output matrix locations.
 
-        On gfx9, we print should print block information because gfx9 supports matrix blocks.
+        In gfx9, we print should print block information because gfx9 supports matrix blocks.
         This child specialization of the function is meant specifically to set a default
         value of print_block=True.
 
         Args:
-            print_block: True if this equation should print information about blocks.
+            print_block: True if this equation should print information about blocks
         """
         super()._print_register_to_element_eqn(print_block)
 
 
 class InstCalcGfx11(InstCalc):
-    """ Calculator for matrix multiplication instruction details on gfx11 architecture.
+    """ Calculator for matrix multiplication instruction details in gfx11 architecture.
 
     This is a child class of the InstCalc class, because gfx11/RDNA3 requires different
     calculations that other architectures.
@@ -5378,8 +5372,8 @@ class InstCalcGfx11(InstCalc):
             b_lanes: list of integers containing all the lanes of B to query
 
         Returns:
-            Integer from the available lanes of B that match the requested lane of A.
-            On gfx11, the A and B matrix entries are lane-matched. As such, this
+            Integer from the available lanes of B that match the requested lane of A
+            In gfx11, the A and B matrix entries are lane-matched. As such, this
             returns the same lane as A.
         """
         del b_lanes # Unused in gfx11
@@ -5404,7 +5398,7 @@ class InstCalcGfx11(InstCalc):
             Based on the matrix and requested coordinates, return two things in a tuple:
             1. String register name that holds the element, in the format V#.[bits]
             2. List of integers, containing the lane numbers within that register that
-                hold the element.
+                hold the element
             Tuple: (register holding the matrix entry, lanes within that register)
         """
         reg = self._get_reg_name(data_size, False, False, 0, 0, k)
@@ -5441,7 +5435,7 @@ class InstCalcGfx11(InstCalc):
             Based on the matrix and requested coordinates, return two things in a tuple:
             1. String register name that holds the element, in the format V#.[bits]
             2. List of integers, containing the lane numbers within that register that
-                hold the element.
+                hold the element
             Tuple: (register holding the matrix entry, lanes within that register)
         """
         # When the output is 16b, we only write into the lower or upper half of
@@ -5486,7 +5480,7 @@ class InstCalcGfx11(InstCalc):
             1. String requested element name, in the format A[i][k], B[k][j], or C[i][j]
             2. String register name that holds the element, in the format V#.[bits]
             3. List of integers, containing the lane numbers within that register that
-                hold the element.
+                hold the element
             Tuple: (matrix entry, register holding that entry, lanes within that register)
         """
         del block, cbsz, abid, blgp # Unused in gfx11
@@ -5509,7 +5503,7 @@ class InstCalcGfx11(InstCalc):
         return (element_name, reg, lanes)
 
     def _calculate_initial_regno_offset(self, matrix: str, opsel: int) -> int:
-        """ Calculates an offset into a register slot based on OPSEL
+        """ Calculates an offset into a register slot based on OPSEL.
 
         On some architectures, partial registers (such as a 16b output in a 32b register)
         aren't tightly packed. For example, "lower" or "upper halves may be skipped
@@ -5520,15 +5514,16 @@ class InstCalcGfx11(InstCalc):
         This function returns an offset, so that these slots (which we call regnos) can
         be skipped.
 
-        On gfx11, 16b outputs only use the top or bottom half of the registers, not both at
+        In gfx11, 16b outputs only use the top or bottom half of the registers, not both at
         the same time. Opsel=0 selects to store into the bottom half, Opsel=4 selects to store
-        into the upper half. As such, when we are on gfx11, looking at the C/D matrix,
+        into the upper half. As such, when we are in gfx11, looking at the C/D matrix,
         and the output is 4, we only actually print half as many output registers. And
         further, when opsel == 4, we bump forward one regno to hit the top half of
         the register.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are a, b, c, and d
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, and d.
             opsel: integer value of the instruction's OPSEL modifier
 
         Returns:
@@ -5553,14 +5548,15 @@ class InstCalcGfx11(InstCalc):
         This function returns the number of slots to print in each register; the rest can
         be skipped.
 
-        On gfx11, 16b outputs only use the top or bottom half of the registers, not both at
-        the same time. As such, when we are on gfx11, looking at the C/D matrix,
+        In gfx11, 16b outputs only use the top or bottom half of the registers, not both at
+        the same time. As such, when we are in gfx11, looking at the C/D matrix,
         and the output is 4, we only actually print half as many output registers.
         Leave "gpr_ratio" the same, however, so that we skip over both halves when we
         are iterating over things.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are a, b, c, and d
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, and d.
             gpr_ratio: the number of regnos in each GPR
 
         Returns:
@@ -5595,10 +5591,10 @@ class InstCalcGfx11(InstCalc):
                     [31:24]: the most significant 8b of a 32b register
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, or d
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, or d.
             requested_output: string that indicates the type of output, from the list of
-                csv, markdown, asciidoc, or grid.
+                csv, markdown, asciidoc, or grid
             negate: dictionary of matrix names to bools that indicate whether to
                 negate and absolute-val entries from this matrix.
             cbsz: integer value of the instruction's CBSZ modifier
@@ -5607,7 +5603,7 @@ class InstCalcGfx11(InstCalc):
             opsel: integer value of the instruction's OPSEL modifier
             transpose: boolean set to true to cause the matrix to be printed transposed
             print_blocks: boolean set to true if this architecture and instruction
-                should print the word "Block #" above each block of the matrix.
+                should print the word "Block #" above each block of the matrix
                 gfx11 does not do this by default.
         """
         super().calculate_register_layout(matrix, requested_output, negate, cbsz, abid, blgp,
@@ -5628,10 +5624,10 @@ class InstCalcGfx11(InstCalc):
         show rows as columns and vice versa.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a, b, c, or d
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, or d.
             requested_output: string that indicates the type of output, from the list of
-                csv, markdown, asciidoc, or grid.
+                csv, markdown, asciidoc, or grid
             negate: dictionary of matrix names to bools that indicate whether to
                 negate and absolute-val entries from this matrix.
             cbsz: integer value of the instruction's CBSZ modifier
@@ -5640,7 +5636,7 @@ class InstCalcGfx11(InstCalc):
             opsel: integer value of the instruction's OPSEL modifier
             transpose: boolean set to true to cause the matrix to be printed transposed
             contig_values: an integer that defines the number of contiguous values of a
-                register that are used to hold unique values of a matrix.
+                register that are used to hold unique values of a matrix
                 gfx11 uses 16 lanes by default.
         """
         super().calculate_matrix_layout(matrix, requested_output, negate, cbsz, abid, blgp, opsel,
@@ -5651,11 +5647,12 @@ class InstCalcGfx11(InstCalc):
         """ Calculates the number of GPRs needed to hold a matrix.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are a, b, c, or d
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, or d.
             in_lanes: an integer that defines the number of contiguous lanes that are used to hold
-                values of a matrix. On gfx11, this is always 16, so the default of this
+                values of a matrix; in gfx11, this is always 16, so the default of this
                 argument is 16.
-            out_size: The number of bits used to hold output values for this instruction.
+            out_size: The number of bits used to hold output values for this instruction
                 For instance: some devices may store 16b values into either the low or high
                 half of a 32b output register. If this argument is not passed in, the function
                 will initialize the value to 32.
@@ -5670,13 +5667,13 @@ class InstCalcGfx11(InstCalc):
     def _coord_to_input_reg_eqn(self, matrix: str) -> str:
         """ Returns formula for mapping a matrix coordinate to its input register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the input register that holds a particular entry in the matrix from its
         i/j/k/block coordinates.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a or b
+            matrix: string that contains the name of the matrix
+                Legal values are a or b.
 
         Returns:
             String that contains the simple formula mapping coordinates to input registers
@@ -5694,7 +5691,7 @@ class InstCalcGfx11(InstCalc):
     def _coord_to_output_reg_eqn(self) -> str:
         """ Returns formula for mapping a matrix coordinate to its output register number.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the output register that holds a particular entry in the matrix from its
         i/j/k/block coordinates.
 
@@ -5709,12 +5706,13 @@ class InstCalcGfx11(InstCalc):
     def _coord_to_lane_eqn(self, matrix: str) -> str:
         """ Returns formula for mapping a matrix coordinate to its wavefront lane.
 
-        Take the instruction info and matrix, return a string with an equation that lets a user
+        Takes the instruction info and matrix, return a string with an equation that lets a user
         calculate the lane that holds a particular entry in the matrix from its i/j/k/block
         coordinates.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are a, b, c, or d
+            matrix: string that contains the name of the matrix
+                Legal values are a, b, c, or d.
 
         Returns:
             String that contains the simple formula mapping coordinates to lanes
@@ -5735,10 +5733,10 @@ class InstCalcGfx11(InstCalc):
         and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix.
+            matrix: string that contains the name of the matrix
 
         Returns:
-            A blank string, because there are no blocks on gfx11
+            A blank string, because there are no blocks in gfx11
         """
         del matrix # Unused in gfx11
         return ""
@@ -5746,14 +5744,14 @@ class InstCalcGfx11(InstCalc):
     def _print_element_to_register_eqn(self, block: str = "") -> None:
         """ Prints formula for matrix entry to GPR and lane mapping.
 
-        Print out the simple formulae to calculate the the mapping of a matrix element to its
+        Prints out the simple formulae to calculate the the mapping of a matrix element to its
         register and lane.
 
         Will always print A[], B[], and D[]. If the instruction allows C[] matrices, then it will
         print D[] as "C or D[i][j]".
 
         Args:
-            block: string that contains text to place in the matrix entry map for blocks.
+            block: string that contains text to place in the matrix entry map for blocks
                 For instance, gfx11 does not uses blocks, so by default this function passes an
                 empty string, to print an entry as A[i][k]
         """
@@ -5766,11 +5764,12 @@ class InstCalcGfx11(InstCalc):
         calculate the i coordinate for the A, C, or D matrices.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are a, c, or d
+            matrix: string that contains the name of the matrix
+                Legal values are a, c, or d.
 
         Returns:
             A string which contains the equation to calculate the i coordinate for
-            an input matrix held by a particular register and lane combination.
+            an input matrix held by a particular register and lane combination
         """
         ret_string = super()._reg_lane_to_i_coord_eqn(matrix)
         if matrix not in ('a', 'b', 'k'):
@@ -5787,12 +5786,12 @@ class InstCalcGfx11(InstCalc):
         Targets a particular instruction, and does not handle modifiers.
 
         Args:
-            matrix: string that contains the name of the matrix. Legal values are
-                a or b
+            matrix: string that contains the name of the matrix
+                Legal values are a or b.
 
         Returns:
             A string which contains the equation to calculate the k coordinate held by a
-            particular register and lane combination.
+            particular register and lane combination
         """
         del matrix # Unused in gfx11, both input matrices have the same layout
         data_size = get_data_size(self.inst_info['in_type'])
@@ -5809,7 +5808,7 @@ class InstCalcGfx11(InstCalc):
 
         Args:
             encoding_name: String containing the name of the encoding format for the
-                current architecture. Defaults to "VOP3P" on gfx11.
+                current architecture; defaults to "VOP3P" in gfx11.
         """
         super()._print_opcode(encoding_name)
 
@@ -5823,7 +5822,7 @@ class InstCalcGfx11(InstCalc):
 
         Args:
             encoding_name: String containing the name of the encoding format for the
-                current architecture. gfx11 defaults to "VOP3P".
+                current architecture; gfx11 defaults to "VOP3P".
         """
         super()._print_register_info(encoding_name)
         print("    Register modifiers:")
@@ -5839,9 +5838,9 @@ class InstCalcGfx11(InstCalc):
         The instruction and architecture are part of the class.
 
         Args:
-            cu_name: string that contains the name of the compute unit on the target arch.
+            cu_name: string that contains the name of the compute unit on the target arch
                 Different architectures may use e.g., CU, or WGP, or some other name.
-                Defaults to "WGP" on gfx11.
+                Defaults to "WGP" in gfx11.
         """
         super()._print_execution_statistics(cu_name)
 
@@ -5852,11 +5851,11 @@ class InstCalcGfx11(InstCalc):
         instruction on a target architecture. Some architectures support more than one
         wavefront size. In that case, print out the register usage for each wavefront size.
         This is needed because different wavefront sizes can cause different GPR usage for
-        the same matris size.
+        the same matrix size.
 
         Args:
-            wave_sizes: a tuple of wavefront sizes to use to print this info.
-                Defaults to a truple of integers 32 and 64 on gfx11, because gfx11
+            wave_sizes: a tuple of wavefront sizes to use to print this info
+                Defaults to a tuple of integers 32 and 64 in gfx11, because gfx11
                 supports both wave32 and wave64.
         """
         super()._print_register_usage(wave_sizes)

--- a/matrix_calculator.py
+++ b/matrix_calculator.py
@@ -70,7 +70,7 @@ except ImportError:
     from typing_extensions import TypedDict
 from tabulate import tabulate
 
-VERSION = "1.2"
+VERSION = "1.2.1"
 
 # Dictionary of possible names for the various supported architectures
 dict_isas = {
@@ -147,11 +147,11 @@ dict_math_types: Dict[str, MatrixNumericalType] = {
         'size': 8,
         'description': 'int8 (Signed 8-bit integer)',
     },
-    'fp8': {
+    'amd_fp8': {
         'size': 8,
         'description': 'FP8 (AMD 4-bit exponent, 3-bit mantissa floating point)',
     },
-    'bf8': {
+    'amd_bf8': {
         'size': 8,
         'description': 'BF8 (AMD 5-bit exponent, 2-bit mantissa floating point)',
     },
@@ -1931,8 +1931,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_16x16x32_bf8_bf8': {
             'arch': 'cdna3',
             'opcode': 112,
-            'in_type': 'bf8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -1953,8 +1953,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_16x16x32_bf8_fp8': {
             'arch': 'cdna3',
             'opcode': 113,
-            'in_type': 'bf8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -1975,8 +1975,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_16x16x32_fp8_bf8': {
             'arch': 'cdna3',
             'opcode': 114,
-            'in_type': 'fp8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -1997,8 +1997,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_16x16x32_fp8_fp8': {
             'arch': 'cdna3',
             'opcode': 115,
-            'in_type': 'fp8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -2019,8 +2019,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_32x32x16_bf8_bf8': {
             'arch': 'cdna3',
             'opcode': 116,
-            'in_type': 'bf8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2041,8 +2041,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_32x32x16_bf8_fp8': {
             'arch': 'cdna3',
             'opcode': 117,
-            'in_type': 'bf8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2063,8 +2063,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_32x32x16_fp8_bf8': {
             'arch': 'cdna3',
             'opcode': 118,
-            'in_type': 'fp8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2085,8 +2085,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_mfma_f32_32x32x16_fp8_fp8': {
             'arch': 'cdna3',
             'opcode': 119,
-            'in_type': 'fp8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2107,8 +2107,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_16x16x64_bf8_bf8': {
             'arch': 'cdna3',
             'opcode': 120,
-            'in_type': 'bf8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -2129,8 +2129,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_16x16x64_bf8_fp8': {
             'arch': 'cdna3',
             'opcode': 121,
-            'in_type': 'bf8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -2151,8 +2151,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_16x16x64_fp8_bf8': {
             'arch': 'cdna3',
             'opcode': 122,
-            'in_type': 'fp8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -2173,8 +2173,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_16x16x64_fp8_fp8': {
             'arch': 'cdna3',
             'opcode': 123,
-            'in_type': 'fp8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 16,
             'n': 16,
@@ -2195,8 +2195,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_32x32x32_bf8_bf8': {
             'arch': 'cdna3',
             'opcode': 124,
-            'in_type': 'bf8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2217,8 +2217,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_32x32x32_bf8_fp8': {
             'arch': 'cdna3',
             'opcode': 125,
-            'in_type': 'bf8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_bf8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2239,8 +2239,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_32x32x32_fp8_bf8': {
             'arch': 'cdna3',
             'opcode': 126,
-            'in_type': 'fp8',
-            'in_type_src1': 'bf8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_bf8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2261,8 +2261,8 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
         'v_smfmac_f32_32x32x32_fp8_fp8': {
             'arch': 'cdna3',
             'opcode': 127,
-            'in_type': 'fp8',
-            'in_type_src1': 'fp8',
+            'in_type': 'amd_fp8',
+            'in_type_src1': 'amd_fp8',
             'out_type': 'fp32',
             'm': 32,
             'n': 32,
@@ -2904,10 +2904,13 @@ def parse_and_run() -> int:
             return -2
     # On RDNA3 architectures, the NEG field is used for two things: for FP operations, its
     # three bits are used to negate the values of the A, B, and C matrices, respectively.
-    # Fo FP, NEG[0] and NEG[1] affect the low 16 bits of each A and B register, respectively.
+    # For FP, NEG[0] and NEG[1] affect the low 16 bits of each A and B register, respectively.
     # To fully negate an input matrix, the NEG_HI field in the instruction should also be set.
     # For floating-point inputs, NEG_HI[0] and NEG_HI[1] negate the high 16 bits of each
     # A and B register, respectively.
+    # For floating-point outputs, NEG[2] causes the instruction to subtract (instead of add)
+    # the C matrix, while NEG_HI[2] causes the addition/subtraction of the absolute value of
+    # the C matrix.
     # For integer instructions, the first two bits are used to set the A and B matrices to
     # signed/unsigned respectively and the third bit must-be-zero. NEG_HI must be 0 for integers.
     if (int(args.neg) > 0 or int(args.neg_hi) > 0):
@@ -2929,13 +2932,25 @@ def parse_and_run() -> int:
                 print("When using the D matrix, the NEG modifier may ", end="", file=sys.stderr)
                 print("only be used when asking for the --output-calculation.", file=sys.stderr)
                 return -2
-        if int(args.neg) > 7:
-            print("The NEG modifier may only contain values between ", end="", file=sys.stderr)
-            print("0 - 7, inclusive.", file=sys.stderr)
+        max_neg_val = 7
+        max_neg_hi_val = 7
+        if inst_info['integer']:
+            max_neg_val = 3
+            max_neg_hi_val = 0
+        if int(args.neg) > max_neg_val:
+            print(f"For the instruction {inst_to_use.upper()} in the ", end="", file=sys.stderr)
+            print(f"{arch_to_use.upper()} architecture, ", end="", file=sys.stderr)
+            print("the NEG modifier may only contain values between ", end="", file=sys.stderr)
+            print(f"0 - {max_neg_val}, inclusive.", file=sys.stderr)
             return -2
-        if int(args.neg_hi) > 7:
-            print("The NEG_HI modifier may only contain values between ", end="", file=sys.stderr)
-            print("0 - 7, inclusive.", file=sys.stderr)
+        if int(args.neg_hi) > max_neg_hi_val:
+            print(f"For the instruction {inst_to_use.upper()} in the ", end="", file=sys.stderr)
+            print(f"{arch_to_use.upper()} architecture, ", end="", file=sys.stderr)
+            print("the NEG_HI modifier may only contain values ", end="", file=sys.stderr)
+            if max_neg_hi_val == 0:
+                print("of 0.", file=sys.stderr)
+            else:
+                print(f"between 0 - {max_neg_hi_val}, inclusive.", file=sys.stderr)
             return -2
 
     negate = {'a': False, 'a_lo': False, 'a_hi': False, 'b': False, 'b_lo': False, 'b_hi': False,
@@ -3337,7 +3352,7 @@ class InstCalc(metaclass=ABCMeta):
 
     @abstractmethod
     def _find_matching_b_lane(self, a_lane: int, b_lanes: List[int]) -> int:
-        """ Finds the lane in a list of B matrix lanes that match the A matirx lane.
+        """ Finds the lane in a list of B matrix lanes that match the A matrix lane.
 
         This is an abstract method, and should be filled in by any child class to
         actually calculate this data for the target architecture.
@@ -3347,7 +3362,7 @@ class InstCalc(metaclass=ABCMeta):
         the matrix. If a value was stored in both lanes 0 and lane 16, when printing
         out "lane 0 of A is multiplied by lane X of B", this function will do that
         matching. It takes as an argument a list of lanes from B, and the requested
-        lane of A. Returned the lane of B that is multiplied by the reuqested ane of A.
+        lane of A. Returns the lane of B that is multiplied by the requested lane of A.
 
         Args:
             a_lane: integer for the lane of A that we want to match
@@ -4715,14 +4730,14 @@ class InstCalcGfx9(InstCalc):
             further calculations.
     """
     def _find_matching_b_lane(self, a_lane: int, b_lanes: List[int]) -> int:
-        """ Finds the lane in a list of B matrix lanes that match the A matirx lane.
+        """ Finds the lane in a list of B matrix lanes that match the A matrix lane.
 
         In some architectures, matrix values can exist simultaneously in multiple
         lanes. Or, more specifically, multiple lanes must store the same value from
         the matrix. If a value was stored in both lanes 0 and lane 16, when printing
         out "lane 0 of A is multiplied by lane X of B", this function will do that
         matching. It takes as an argument a list of lanes from B, and the requested
-        lane of A. Returned the lane of B that is multiplied by the reuqested ane of A.
+        lane of A. Returns the lane of B that is multiplied by the requested lane of A.
 
         In gfx9, B matrix only has a single lane per entry, like A matrix.
         As such, just return the first lane of B.
@@ -5496,14 +5511,14 @@ class InstCalcGfx11(InstCalc):
     """
 
     def _find_matching_b_lane(self, a_lane: int, b_lanes: List[int]) -> int:
-        """ Finds the lane in a list of B matrix lanes that match the A matirx lane.
+        """ Finds the lane in a list of B matrix lanes that match the A matrix lane.
 
         In some architectures, matrix values can exist simultaneously in multiple
         lanes. Or, more specifically, multiple lanes must store the same value from
         the matrix. If a value was stored in both lanes 0 and lane 16, when printing
         out "lane 0 of A is multiplied by lane X of B", this function will do that
         matching. It takes as an argument a list of lanes from B, and the requested
-        lane of A. Returned the lane of B that is multiplied by the reuqested ane of A.
+        lane of A. Returns the lane of B that is multiplied by the requested lane of A.
 
         Args:
             a_lane: integer for the lane of A that we want to match

--- a/matrix_calculator.py
+++ b/matrix_calculator.py
@@ -71,7 +71,7 @@ except ImportError:
     from typing_extensions import TypedDict
 from tabulate import tabulate
 
-VERSION = "1.2.2"
+VERSION = "1.2.3"
 
 # Dictionary of possible names for the various supported architectures
 dict_isas = {
@@ -1305,7 +1305,7 @@ dict_insts: Dict[str, Dict[str, MatrixInstruction]] = {
             'integer': False,
             'c_d_arch': True,
             'gpr_byte_align': 8,
-            'blgp': True,
+            'blgp': False,
             'cbsz_abid': False,
             'sparse': False,
             'cd_opsel': False,

--- a/test/.pylintrc
+++ b/test/.pylintrc
@@ -33,7 +33,9 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # some complex nesting. This is not universally good software engineering pratice,
 # but this makes some of the code (such as loops handling multi-dimensional matrix
 # unrolling) more natural.
-disable=too-many-arguments,
+disable=unknown-option-value,
+        too-many-arguments,
+        too-many-positional-arguments,
         too-many-branches,
         too-many-locals,
         too-many-lines,

--- a/test/.pylintrc
+++ b/test/.pylintrc
@@ -72,3 +72,4 @@ ignore-comments=yes
 ignore-docstrings=yes
 ignore-imports=no
 defining-attr-methods=__init__
+load-plugins=pylint.extensions.no_self_use


### PR DESCRIPTION
This PR is a collection of updates to the matrix tool, the main README file, and pylint.

Broadly, these fix a number of typos, grammar problems, and pylint warnings. Also adds new sub-architectures and SKUs that were not yet released at the last update. Fixes a mistake in the CDNA3 instruction database, and pulls a few other calculations into different locations in order to clean up per-architecture split.